### PR TITLE
Reverse query to report owners with 0 patches merged

### DIFF
--- a/reports/open-changesets-by-owner-newbie.py
+++ b/reports/open-changesets-by-owner-newbie.py
@@ -45,12 +45,12 @@ SELECT
   SUM( gc_project == 'mediawiki/core' ) as open_core
 FROM changesets
 WHERE gc_status = 'NEW'
-AND gc_owner IN (
+AND gc_owner NOT IN (
   SELECT gc_owner
   FROM changesets
   WHERE gc_status = 'MERGED'
   GROUP BY gc_owner
-  HAVING COUNT( gc_owner ) < 5
+  HAVING COUNT( gc_owner ) >= 5
 )
 GROUP BY gc_owner;
 ''')


### PR DESCRIPTION
No wonder they were not reported: we were looking for those with less than 5
merged patches among those with merged patches. Quick solution is reversing
the query, probably not the most efficient way or maybe yes if newbies grow
more than serial patchers.
